### PR TITLE
Create static landing site for Rank & Forge

### DIFF
--- a/rankandforge-landing/README.md
+++ b/rankandforge-landing/README.md
@@ -1,0 +1,14 @@
+# Rank & Forge — Static Landing (Cloudflare Pages)
+
+## Deploy
+- Create Cloudflare Pages project → Framework preset: None → Output dir: `/`.
+- Set custom domain `rankandforge.com`.
+
+## Configure
+- Replace `FORM_ID` in `index.html` with your Formspree endpoint.
+- Replace `YOUR_CF_ANALYTICS_TOKEN` with your Cloudflare Web Analytics token.
+- Swap `/assets/logo.svg` with your final logo and add a branded Open Graph image at `/assets/og.png` when available.
+
+## Notes
+- CSP allows Google Fonts + Formspree. If you add scripts, update CSP.
+- Honeypot `_hp` reduces spam. Enable Formspree spam filter too.

--- a/rankandforge-landing/assets/logo.svg
+++ b/rankandforge-landing/assets/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="132" height="32" viewBox="0 0 132 32" role="img" aria-label="Rank & Forge">
+  <rect width="132" height="32" rx="6" fill="#2F4858"/>
+  <text x="50%" y="55%" dominant-baseline="middle" text-anchor="middle" font-family="Merriweather, Georgia, serif" font-size="14" fill="#F4F4F4">Rank & Forge</text>
+</svg>

--- a/rankandforge-landing/assets/styles.css
+++ b/rankandforge-landing/assets/styles.css
@@ -1,0 +1,28 @@
+:root{
+  --ink:#1C1C1C; --steel:#2F4858; --copper:#B97A56; --linen:#F4F4F4;
+  --max:72rem; --pad:1rem; --radius:.75rem;
+}
+*{box-sizing:border-box} html{scroll-behavior:smooth}
+body{margin:0;color:var(--ink);background:#fff;font-family:"Figtree",system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,"Helvetica Neue",Arial,sans-serif;line-height:1.6}
+h1,h2,h3{font-family:"Merriweather",Georgia,"Times New Roman",serif;line-height:1.2;margin:.5em 0}
+a{color:var(--steel);text-decoration:none}
+a:hover{text-decoration:underline}
+.container{max-width:var(--max);margin-inline:auto;padding:0 var(--pad)}
+.header{padding:1rem 0;border-bottom:1px solid #eee}
+.nav{display:flex;align-items:center;justify-content:space-between;gap:1rem}
+.nav ul{display:flex;gap:1rem;list-style:none;margin:0;padding:0}
+.hero{padding:4rem 0;background:linear-gradient(180deg,#fff, var(--linen))}
+.cta{display:inline-block;padding:.75rem 1rem;border-radius:var(--radius);background:var(--steel);color:#fff;font-weight:600}
+.cta.secondary{background:var(--copper)}
+.grid{display:grid;gap:1rem}
+@media(min-width:768px){.grid.cols-2{grid-template-columns:1fr 1fr}.grid.cols-4{grid-template-columns:repeat(4,1fr)}}
+.card{border:1px solid #eee;border-radius:var(--radius);padding:1rem;background:#fff}
+.section{padding:3rem 0}
+.footer{padding:2rem 0;border-top:1px solid #eee;font-size:.9rem}
+label{display:block;font-weight:600;margin:.5rem 0}
+input,textarea{width:100%;padding:.6rem;border:1px solid #ddd;border-radius:.5rem;font:inherit}
+textarea{min-height:140px;resize:vertical}
+button{cursor:pointer}
+.hp{position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden}
+.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
+.badge{display:inline-block;background:var(--linen);border:1px solid #e6e6e6;border-radius:999px;padding:.25rem .6rem;font-size:.85rem}

--- a/rankandforge-landing/index.html
+++ b/rankandforge-landing/index.html
@@ -1,0 +1,145 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Rank & Forge | Driving Growth for Services Companies</title>
+<meta name="description" content="Rank & Forge helps services companies get found and booked with SEO, Google Maps optimization, ads, and simple sales automation.">
+<link rel="icon" href="/favicon.ico">
+<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Figtree:wght@400;600&family=Merriweather:wght@700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/assets/styles.css">
+<meta property="og:title" content="Rank & Forge">
+<meta property="og:description" content="Driving growth for services companies.">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://rankandforge.com/">
+<meta property="og:image" content="https://rankandforge.com/assets/logo.svg">
+<meta name="twitter:card" content="summary_large_image">
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' data:; script-src 'self' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; connect-src https://formspree.io; form-action https://formspree.io">
+<script type="application/ld+json">
+{
+ "@context":"https://schema.org",
+ "@type":"Organization",
+ "name":"Rank & Forge",
+ "url":"https://rankandforge.com",
+ "logo":"https://rankandforge.com/assets/logo.svg",
+ "sameAs":[
+  "https://x.com/rankandforge",
+  "https://www.linkedin.com/company/rankandforge",
+  "https://instagram.com/rankandforge"
+ ]
+}
+</script>
+</head>
+<body>
+
+<a class="sr-only" href="#main">Skip to content</a>
+
+<header class="header">
+  <div class="container nav">
+    <a href="/"><img src="/assets/logo.svg" alt="Rank & Forge logo" width="132" height="32"></a>
+    <nav aria-label="Primary">
+      <ul>
+        <li><a href="#services">Services</a></li>
+        <li><a href="#about">About</a></li>
+        <li><a class="badge" href="#contact">Contact</a></li>
+      </ul>
+    </nav>
+  </div>
+</header>
+
+<section class="hero">
+  <div class="container">
+    <h1>Driving growth for services companies</h1>
+    <p>We make contractors and B2B service providers easier to find and simpler to hire.</p>
+    <p><a href="#contact" class="cta" role="button">Get a free audit</a></p>
+  </div>
+</section>
+
+<main id="main">
+  <section class="section" id="services">
+    <div class="container">
+      <h2>What we do</h2>
+      <div class="grid cols-4">
+        <div class="card"><h3>Search Engine Optimization</h3><p>Technical fixes and content that rank locally and drive qualified traffic.</p></div>
+        <div class="card"><h3>Google Maps Optimization</h3><p>Google Business Profile tuning, citations, and reviews to win the map pack.</p></div>
+        <div class="card"><h3>Ads Management</h3><p>Simple, targeted campaigns that generate calls and form fills profitably.</p></div>
+        <div class="card"><h3>Sales Process Automation</h3><p>Lightweight follow-ups and tracking so more leads turn into booked jobs.</p></div>
+      </div>
+    </div>
+  </section>
+
+  <section class="section" id="about">
+    <div class="container grid cols-2">
+      <div>
+        <h2>About Rank & Forge</h2>
+        <p>We focus on the boring work that compounds: correct technical setup, clear service pages, fast responses, and steady review growth. The objective is simple—more booked work at healthy margins. We start with a quick audit, fix the basics, and scale only what proves ROI.</p>
+        <p><a href="#contact" class="cta secondary">Request an audit</a></p>
+      </div>
+      <div class="card">
+        <h3>Why it works</h3>
+        <ul>
+          <li>Local intent prioritized over vanity traffic</li>
+          <li>Map visibility and reviews as primary levers</li>
+          <li>Lead handling tightened before adding budget</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <section class="section" id="contact" aria-labelledby="contact-heading">
+    <div class="container">
+      <h2 id="contact-heading">Contact</h2>
+      <form action="https://formspree.io/f/FORM_ID" method="POST" accept-charset="UTF-8" novalidate>
+        <div>
+          <label for="name">Name</label>
+          <input id="name" name="name" required autocomplete="name">
+        </div>
+        <div>
+          <label for="email">Email</label>
+          <input id="email" name="email" type="email" required autocomplete="email" inputmode="email">
+        </div>
+        <div>
+          <label for="company">Company (optional)</label>
+          <input id="company" name="company" autocomplete="organization">
+        </div>
+        <div>
+          <label for="message">What do you need?</label>
+          <textarea id="message" name="message" required minlength="20"></textarea>
+        </div>
+
+        <!-- Honeypot -->
+        <input type="text" name="_hp" tabindex="-1" autocomplete="off" aria-hidden="true" class="hp">
+
+        <!-- Redirect after success -->
+        <input type="hidden" name="redirect" value="https://rankandforge.com/thanks">
+
+        <!-- Consent -->
+        <label><input type="checkbox" name="consent" required> You may contact me about this request.</label>
+
+        <button type="submit" id="submit" class="cta">Send</button>
+        <p role="status" aria-live="polite" id="form-status" class="sr-only"></p>
+      </form>
+      <script>
+        const f=document.querySelector('#contact form'); const btn=document.getElementById('submit');
+        f.addEventListener('submit',()=>{ btn.disabled=true; btn.textContent='Sending…'; });
+      </script>
+    </div>
+  </section>
+</main>
+
+<footer class="footer">
+  <div class="container">
+    <p>© <span id="y"></span> Rank & Forge</p>
+    <p>
+      <a href="https://x.com/rankandforge">X</a> ·
+      <a href="https://www.linkedin.com/company/rankandforge">LinkedIn</a> ·
+      <a href="https://instagram.com/rankandforge">Instagram</a> ·
+      <a href="mailto:ops@rankandforge.com">ops@rankandforge.com</a>
+    </p>
+  </div>
+  <script>document.getElementById('y').textContent=new Date().getFullYear()</script>
+  <script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token":"YOUR_CF_ANALYTICS_TOKEN"}'></script>
+</footer>
+
+</body>
+</html>

--- a/rankandforge-landing/robots.txt
+++ b/rankandforge-landing/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://rankandforge.com/sitemap.xml

--- a/rankandforge-landing/sitemap.xml
+++ b/rankandforge-landing/sitemap.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://rankandforge.com/</loc></url>
+  <url><loc>https://rankandforge.com/thanks</loc></url>
+</urlset>

--- a/rankandforge-landing/thanks.html
+++ b/rankandforge-landing/thanks.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Thanks — Rank & Forge</title>
+<link rel="stylesheet" href="/assets/styles.css">
+<main class="section container">
+  <h1>Thanks</h1>
+  <p>We received your message. We’ll reply within one business day.</p>
+  <p><a class="cta" href="/">Back to home</a></p>
+</main>


### PR DESCRIPTION
## Summary
- add Rank & Forge landing page with hero, services, about, and contact form markup
- style the site with shared typography, layout, and utility classes
- document deployment steps, metadata files, and note how to supply final brand assets
- remove the binary Open Graph placeholder and point the OG tag at the logo asset for now

## Testing
- `npx --yes html-validate index.html thanks.html` *(fails: npm 403 when reaching registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d5912df67c83319e37d2e7b38728eb